### PR TITLE
add FFmpex.prepare/1 helper

### DIFF
--- a/test/ffmpex_test.exs
+++ b/test/ffmpex_test.exs
@@ -68,4 +68,20 @@ defmodule FFmpexTest do
 
     assert {:error, {_, 1}} = execute(command)
   end
+
+  test "can prepare arguments" do
+    command =
+      FFmpex.new_command
+      |> add_global_option(option_y())
+      |> add_input_file(@fixture)
+      |> add_output_file(@output_path)
+        |> add_stream_specifier(stream_type: :video)
+          |> add_stream_option(option_b("64k"))
+        |> add_file_option(option_maxrate("128k"))
+        |> add_file_option(option_bufsize("64k"))
+
+    assert {executable, args} = prepare(command)
+    assert Enum.count(args) ==  10
+    assert executable =~  "ffmpeg"
+  end
 end


### PR DESCRIPTION
There're uses cases when the plain `FFmpex.execute/1` is not enough, for example when ffmpeg is run as a live streaming encoder and there is no end of the file. Under such case `FFmpex.execute/1` will never return.

To handle that, a `Port` must be used with a custom process handler, basically an async exec must be created.

So I'm adding a `prepare/1` function which just converts the `Command` struct into the proper args and return a tuple containing the full ffmpeg executable path along with args.

These return values can be used in a `Port.open/2` command, for example, while keeping the power of ffmpex to compose the final command.