### PR TITLE
adding error messages for FFprobe

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,0 +1,3 @@
+[
+  inputs: ["*.{ex,exs}", "priv/*/seeds.exs", "{config,lib,test}/**/*.{ex,exs}"]
+]

--- a/lib/ffprobe.ex
+++ b/lib/ffprobe.ex
@@ -17,7 +17,7 @@ defmodule FFprobe do
   If no duration (e.g., a still image), returns `:no_duration`.
   If the file does not exist, returns { :error, :no_such_file } 
   """
-  @spec duration(binary | format_map) :: float | :no_duration
+  @spec duration(binary | format_map) :: float | :no_duration | { :error, :no_such_file }
   def duration(file_path) when is_binary(file_path) do
     case format(file_path) do
       format = %{} ->

--- a/lib/ffprobe.ex
+++ b/lib/ffprobe.ex
@@ -14,11 +14,17 @@ defmodule FFprobe do
 
   @doc """
   Get the duration in seconds, as a float.
-  If no duration (e.g., a still image), returns `:no_duration`
+  If no duration (e.g., a still image), returns `:no_duration`.
+  If the file does not exist, returns { :error, :no_such_file } 
   """
   @spec duration(binary | format_map) :: float | :no_duration
   def duration(file_path) when is_binary(file_path) do
-    duration(format(file_path))
+    with format = %{} <- format(file_path) do
+      duration(format)
+    else
+      {:error, :invalid_file} ->
+        duration(%{"duration" => nil})
+    end
   end
 
   def duration(format_map) when is_map(format_map) do
@@ -30,10 +36,14 @@ defmodule FFprobe do
 
   @doc """
   Get a list of formats for the file.
+  If the file does not exist, returns { :error, :no_such_file }.
+  If the file is a non media file, returns { :error, :invalid_file }.
   """
   @spec format_names(binary | format_map) :: [binary]
   def format_names(file_path) when is_binary(file_path) do
-    format_names(format(file_path))
+    with format = %{} <- format(file_path) do
+      format_names(format)
+    end
   end
 
   def format_names(format_map) when is_map(format_map) do
@@ -43,32 +53,67 @@ defmodule FFprobe do
   @doc """
   Get the "format" map, containing general info for the specified file,
   such as number of streams, duration, file size, and more.
+  If the file does not exist, returns { :error, :no_such_file }.
+  If the file is a non media file, returns { :error, :invalid_file }.
   """
   @spec format(binary) :: format_map | no_return
   def format(file_path) do
-    cmd_args = ["-v", "quiet", "-print_format", "json", "-show_format", file_path]
-    {result, 0} = System.cmd(ffprobe_path(), cmd_args, stderr_to_stdout: true)
+    case File.exists?(file_path) do
+      false ->
+        {:error, :no_such_file}
 
-    result
-    |> Jason.decode!()
-    |> Map.get("format", %{})
+      true ->
+        cmd_args = ["-v", "quiet", "-print_format", "json", "-show_format", file_path]
+
+        case System.cmd(ffprobe_path(), cmd_args, stderr_to_stdout: true) do
+          {result, 0} ->
+            result
+            |> Jason.decode!()
+            |> Map.get("format", %{})
+
+          {_result, 1} ->
+            {:error, :invalid_file}
+        end
+    end
   end
 
+  @doc """
+  Get a list a of streams from the file. 
+  If the file does not exist, returns { :error, :no_such_file }.
+  If the file is a non media file, returns { :error, :invalid_file }.
+  """
   @spec streams(binary) :: streams_list | no_return
   def streams(file_path) do
-    cmd_args = ["-v", "quiet", "-print_format", "json", "-show_streams", file_path]
-    {result, 0} = System.cmd(ffprobe_path(), cmd_args, stderr_to_stdout: true)
+    case File.exists?(file_path) do
+      false ->
+        {:error, :no_such_file}
 
-    result
-    |> Jason.decode!()
-    |> Map.get("streams", [])
+      true ->
+        cmd_args = ["-v", "quiet", "-print_format", "json", "-show_streams", file_path]
+
+        case System.cmd(ffprobe_path(), cmd_args, stderr_to_stdout: true) do
+          {result, 0} ->
+            result
+            |> Jason.decode!()
+            |> Map.get("streams", [])
+
+          {_result, 1} ->
+            {:error, :invalid_file}
+        end
+    end
   end
 
-  # Read ffprobe path from config. If unspecified, assume `ffprobe` is in env $PATH.
+  # Read ffprobe path from config. If unspecified, check if `ffprobe` is in env $PATH.
+  # If it is not, then raise a error.
   defp ffprobe_path do
     case Application.get_env(:ffmpex, :ffprobe_path, nil) do
-      nil -> System.find_executable("ffprobe")
-      path -> path
+      nil ->
+        with nil <- System.find_executable("ffprobe") do
+          raise "FFmpeg not installed"
+        end
+
+      path ->
+        path
     end
   end
 end

--- a/test/ffprobe_test.exs
+++ b/test/ffprobe_test.exs
@@ -31,6 +31,18 @@ defmodule FFprobeTest do
     assert streams |> Enum.at(1) |> Map.get("codec_name") == "aac"
   end
 
+  test "stream/1 should return a error when the given file does not exist" do
+    assert {:error, :no_such_file} == FFprobe.streams("hej")
+  end
+
+  test "format/1 should return a error when the given file does not exist" do
+    assert {:error, :no_such_file} == FFprobe.format("hej")
+  end
+
+  test "format_names/1 should return a error when the given file does not exist" do
+    assert {:error, :no_such_file} == FFprobe.format_names("hej")
+  end
+
   test "format names include expected formats" do
     result = FFprobe.format_names(@fixture_mp4)
     assert "mp4" in result


### PR DESCRIPTION
This commit adds error messages to FFprobe.
Whenever one tries to use streams/1 or
format/1 on a nonexisting or nonmedia file,
it gives the user a error tuple.