### PR TITLE
Adds :ok tuples to public FFprobe functions

### DIFF
--- a/test/ffprobe_test.exs
+++ b/test/ffprobe_test.exs
@@ -16,23 +16,35 @@ defmodule FFprobeTest do
   end
 
   test "format has at least one expected key" do
-    assert %{"nb_streams" => 2} = FFprobe.format(@fixture)
+    assert {:ok, %{"nb_streams" => 2} } = FFprobe.format(@fixture)
   end
 
   test "format which filename has space" do
-    assert %{"nb_streams" => 2} = FFprobe.format(@fixture_space)
+    assert {:ok,%{"nb_streams" => 2}} = FFprobe.format(@fixture_space)
   end
 
   test "streams/1" do
-    streams = FFprobe.streams(@fixture_space)
+    assert {:ok,streams} = FFprobe.streams(@fixture_space)
 
     assert is_list(streams)
     assert streams |> Enum.at(0) |> Map.get("codec_name") == "h264"
     assert streams |> Enum.at(1) |> Map.get("codec_name") == "aac"
   end
 
+  test "stream/1 should return a error when the given file does not exist" do
+    assert {:error, :no_such_file} == FFprobe.streams("hej")
+  end
+
+  test "format/1 should return a error when the given file does not exist" do
+    assert {:error, :no_such_file} == FFprobe.format("hej")
+  end
+
+  test "format_names/1 should return a error when the given file does not exist" do
+    assert {:error, :no_such_file} == FFprobe.format_names("hej")
+  end
+
   test "format names include expected formats" do
-    result = FFprobe.format_names(@fixture_mp4)
+    assert {:ok, result} = FFprobe.format_names(@fixture_mp4)
     assert "mp4" in result
     assert "mov" in result
     assert "m4a" in result


### PR DESCRIPTION
Adds {:ok, data } tuples to public
FFprobe functions like format/1
etc. This makes it easier for
users pattern on the result.