### PR TITLE
Allow FFProbe on URL files

### DIFF
--- a/lib/ffprobe.ex
+++ b/lib/ffprobe.ex
@@ -122,6 +122,10 @@ defmodule FFprobe do
     end
   end
 
+  # So we can test our private function
+  @doc false
+  def test_file_exists?(file_path), do: file_exists?(file_path)
+
   # Check we have a valid URL
   # Credit @Tronathan https://stackoverflow.com/questions/39041335/how-to-validate-url-in-elixir
   defp valid_url?(value) do

--- a/test/ffprobe_test.exs
+++ b/test/ffprobe_test.exs
@@ -49,4 +49,12 @@ defmodule FFprobeTest do
     assert "mov" in result
     assert "m4a" in result
   end
+
+  test "file_exists?/1 should return true when the given file_path is a valid url" do
+    assert true == FFprobe.test_file_exists?("http://www.google.com")
+  end
+
+  test "file_exists?/1 should return false when the given file_path is an invalid url" do
+    assert false == FFprobe.test_file_exists?("hej")
+  end
 end


### PR DESCRIPTION
At the moment if it's not a local file, it throws:

`{:error, :no_such_file}`

This change allows URLs as valid file_path