### PR TITLE
Add verbosity flag and fix annoying compiler warnings

### DIFF
--- a/lib/ffmpex.ex
+++ b/lib/ffmpex.ex
@@ -95,7 +95,7 @@ defmodule FFmpex do
   @spec add_stream_specifier(command :: Command.t, opts :: Keyword.t) :: Command.t
   def add_stream_specifier(%Command{files: [file | files]} = command, opts) do
     stream_specifier = struct(StreamSpecifier, opts)
-    file = %File{file | stream_specifiers: [stream_specifier | file.stream_specifiers]}
+    file = %{file | stream_specifiers: [stream_specifier | file.stream_specifiers]}
     %Command{command | files: [file | files]}
   end
 
@@ -116,7 +116,7 @@ defmodule FFmpex do
     %{type: file_io_type} = file
     validate_contexts!(contexts, file_io_type)
 
-    file = %File{file | options: [option | file.options]}
+    file = %{file | options: [option | file.options]}
     %Command{command | files: [file | files]}
   end
 
@@ -130,8 +130,8 @@ defmodule FFmpex do
     validate_contexts!(contexts, file_io_type)
 
     %File{stream_specifiers: [stream_specifier | stream_specifiers]} = file
-    stream_specifier = %StreamSpecifier{stream_specifier | options: [option | stream_specifier.options]}
-    file = %File{file | stream_specifiers: [stream_specifier | stream_specifiers]}
+    stream_specifier = %{stream_specifier | options: [option | stream_specifier.options]}
+    file = %{file | stream_specifiers: [stream_specifier | stream_specifiers]}
     %Command{command | files: [file | files]}
   end
 

--- a/lib/ffmpex/options/main.ex
+++ b/lib/ffmpex/options/main.ex
@@ -9,6 +9,7 @@ defmodule FFmpex.Options.Main do
     i:               %Option{name: "-i", require_arg: true, contexts: [:input]},
     y:               %Option{name: "-y", contexts: [:global]},
     n:               %Option{name: "-n", contexts: [:global]},
+    v:               %Option{name: "-v", require_arg: true, contexts: [:global]},
     stream_loop:     %Option{name: "-stream_loop", require_arg: true, contexts: [:input]},
     c:               %Option{name: "-c", require_arg: true, contexts: [:input, :output, :per_stream]},
     codec:           %Option{name: "-codec", require_arg: true, contexts: [:input, :output, :per_stream]},


### PR DESCRIPTION
Not much to say. Add option_v with required loglevel. Maybe this should accept one of a few permitted options (error, warning,  debug)? There's also all of the loglevel flags so better to keep as an open string for now.

Also fixed the struct update syntax warnings while I was there.

No AI was used in the making of this pull request.

Fixes #46, didn't realize how easy it would be until I started looking.
